### PR TITLE
tests: fix throwing assertion.

### DIFF
--- a/tests/lib/url-rewriter.js
+++ b/tests/lib/url-rewriter.js
@@ -23,17 +23,16 @@ describe("URLRewriter", function() {
 				/*eslint-disable no-unused-vars*/
 				var rewriter = new URLRewriter();
 				/*eslint-enable no-unused-vars*/
-
-			});
-		}, /Constructors expects a function/);
+			}, /Constructor expects a function/);
+		});
 
 		it("should throw an error when the first argument isn't a function", function() {
 			assert.throws(function() {
 				/*eslint-disable no-unused-vars*/
 				var rewriter = new URLRewriter("hallo");
 				/*eslint-enable no-unused-vars*/
-			});
-		}, /Constructors expects a function/);
+			}, /Constructor expects a function/);
+		});
 
 	});
 


### PR DESCRIPTION
The error message regex was previously an argument to the `it` call as opposed to the `assert.throws` call. I noticed because the wording was "Constructor**s** expects", but it was still passing the tests. I moved it to the right function and removed the extra `s`.
