### PR TITLE
Add error handler to URLRewriteStream transform

### DIFF
--- a/lib/url-rewrite-stream.js
+++ b/lib/url-rewrite-stream.js
@@ -73,8 +73,7 @@ URLRewriteStream.prototype._transform = function(data, encoding, done) {
     }
 
     // rewrite the lines
-    var rewriter = new URLRewriter(this.replacer);
-    this.push(rewriter.rewrite(text));
+    this._rewrite(text);
 
     done();
 };
@@ -91,12 +90,27 @@ URLRewriteStream.prototype._flush = function(done) {
     if (this._leftover) {
 
         // rewrite the lines
-        var rewriter = new URLRewriter(this.replacer);
-        this.push(rewriter.rewrite(this._leftover));
+        this._rewrite(this._leftover);
 
     }
 
     done();
+};
+
+/**
+ * Do the actual url rewriting of a chunk, handle errors.
+ * @param  {string} text string to rewrite
+ * @returns {void}
+ * @private
+ */
+URLRewriteStream.prototype._rewrite = function(text) {
+
+    var rewriter = new URLRewriter(this.replacer);
+    try {
+        this.push(rewriter.rewrite(text));
+    } catch (e) {
+        this.emit("error", e);
+    }
 };
 
 /**

--- a/tests/lib/url-rewrite-stream.js
+++ b/tests/lib/url-rewrite-stream.js
@@ -72,6 +72,21 @@ describe("URLRewriteStream", function() {
 
         });
 
+        it("should emit an error event if there's a transform function error", function(done) {
+            var stream = new URLRewriteStream(function() {
+                throw new Error("This is bad");
+            });
+
+            fs.createReadStream("./tests/fixtures/minified-before.css")
+                .pipe(stream);
+
+            stream.on("error", function (e) {
+                assert(e instanceof Error, "it is an Error");
+                done();
+            });
+
+        });
+
     });
 
 });


### PR DESCRIPTION
This is related to #4.

This PR adds an error handler to the `URLRewriteStream`, so that errors in the rewriter (or inside the transform function) are emitted via an `error` event and can be handled in the production code.